### PR TITLE
Refactor category icons and add new categories

### DIFF
--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -12,6 +12,10 @@ import {
   Cloud,
   Shield,
   Smartphone,
+  Coffee,
+  CircuitBoard,
+  TreePine,
+  Settings,
 } from "lucide-react";
 
 const categoryIcons = {
@@ -25,6 +29,12 @@ const categoryIcons = {
   'cloud': Cloud,
   'security': Shield,
   'mobile': Smartphone,
+  'python': TreePine,
+  'java': Coffee,
+  'os': Settings,
+  'dsa': TreePine,
+  'computer-architecture': CircuitBoard,
+
 };
 
 export function Categories() {

--- a/components/category-grid.tsx
+++ b/components/category-grid.tsx
@@ -17,26 +17,37 @@ interface CategoryGridProps {
 }
 
 export function CategoryGrid({ categories, creators }: CategoryGridProps) {
-  const [selectedCategory, setSelectedCategory] = useState(categories[0].slug);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [filteredCreators, setFilteredCreators] = useState<Creator[]>(creators);
 
   useEffect(() => {
-    const filtered = creators.filter(
-      creator => creator.categories.some(category => 
-        category.toLowerCase().includes(selectedCategory.toLowerCase())
-      )
-    );
+    const filtered = selectedCategory
+      ? creators.filter(
+          creator => creator.categories.some(category => 
+            category.toLowerCase().includes(selectedCategory.toLowerCase())
+          )
+        )
+      : creators;
     setFilteredCreators(filtered);
   }, [selectedCategory, creators]);
 
   return (
     <div className="space-y-6">
       <Tabs
-        defaultValue={categories[0].slug}
+        defaultValue=""
         onValueChange={setSelectedCategory}
         className="w-full"
       >
         <TabsList className="w-full h-auto flex flex-wrap gap-2 bg-transparent justify-start">
+          <TabsTrigger
+            value=""
+            className={cn(
+              "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground",
+              "px-4 py-2"
+            )}
+          >
+            All
+          </TabsTrigger>
           {categories.map((category) => (
             <TabsTrigger
               key={category.slug}
@@ -50,6 +61,17 @@ export function CategoryGrid({ categories, creators }: CategoryGridProps) {
             </TabsTrigger>
           ))}
         </TabsList>
+
+        <TabsContent value="">
+          <div className="grid gap-6">
+            <CreatorGrid creators={filteredCreators} />
+            {filteredCreators.length === 0 && (
+              <p className="text-center text-muted-foreground py-8">
+                No creators found.
+              </p>
+            )}
+          </div>
+        </TabsContent>
 
         {categories.map((category) => (
           <TabsContent key={category.slug} value={category.slug}>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,6 +12,11 @@ export const categories: Category[] = [
   { name: 'Cloud', slug: 'cloud' },
   { name: 'Security', slug: 'security' },
   { name: 'Mobile', slug: 'mobile' },
+  { name: 'Python', slug: 'python' },
+  { name: 'Java', slug: 'java' },
+  { name: 'Operating Systems', slug: 'os' },
+  { name: 'DSA', slug: 'dsa' },
+  { name: 'Computer Architecture', slug: 'computer-architecture' },
 ];
 
 export const channelsData: Creator[] = [];


### PR DESCRIPTION
This commit refactors the category icons in the `categories.tsx` component and adds new categories to the `lib/data.ts` file. The `categories.tsx` component now includes icons for `python`, `java`, `os`, `dsa`, and `computer-architecture`. The `lib/data.ts` file now includes new categories for `Python`, `Java`, `Operating Systems`, `DSA`, and `Computer Architecture`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new icons for categories: Coffee, CircuitBoard, TreePine, and Settings.
	- Added new categories: Python, Java, Operating Systems, DSA, and Computer Architecture.
	- Implemented an "All" creators tab for enhanced category selection.

- **Bug Fixes**
	- Improved initial selection behavior in the CategoryGrid component to allow viewing all creators when no specific category is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->